### PR TITLE
Match ImageMagick's resize options and refactoring

### DIFF
--- a/lib/rack/thumb.rb
+++ b/lib/rack/thumb.rb
@@ -201,7 +201,7 @@ module Rack
       dimensions = meta.split('x').map do |dim|
         if dim.empty?
           nil
-        elsif dim[0].to_i == 0
+        elsif dim.index('0') == 0
           throw :halt, bad_request
         else
           dim.to_i

--- a/lib/rack/thumb.rb
+++ b/lib/rack/thumb.rb
@@ -107,7 +107,7 @@ module Rack
 
       response || @app.call(env)
     end
-    
+
     # Extracts filename and options from the path.
     def extract_meta(match)
       result = if @keylen

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -9,14 +9,17 @@ describe Rack::Thumb do
     end)
   end
 
+  def image_dimensions(response)
+    image_info(response.body)[:dimensions]
+  end
+
 
   it "should render a thumbnail with width only" do
     response = mock_request.get("/media/imagick_50x.jpg")
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 52]
+    image_dimensions(response).should == [50, 52]
   end
 
   it "should render a thumbnail with height only" do
@@ -24,8 +27,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [48, 50]
+    image_dimensions(response).should == [48, 50]
   end
 
   it "should render a thumbnail with width and height (crop-resize)" do
@@ -33,8 +35,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 50]
+    image_dimensions(response).should == [50, 50]
   end
 
   it "should render a thumbnail with width, height and gravity (crop-resize)" do
@@ -42,8 +43,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 100]
+    image_dimensions(response).should == [50, 100]
   end
 
   it "should not render a thumbnail that exceeds the original image's dimensions" do
@@ -51,8 +51,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [572, 591]
+    image_dimensions(response).should == [572, 591]
   end
 
   it "should render a thumbnail with a signature" do
@@ -62,8 +61,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 100]
+    image_dimensions(response).should == [50, 100]
   end
 
   it "should pass non-thumbnail image requests to the application" do
@@ -133,8 +131,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 52]
+    image_dimensions(response).should == [50, 52]
   end
 
   it "should return bad request with width of 0" do
@@ -199,8 +196,7 @@ describe Rack::Thumb do
 
     response.should.be.ok
     response.content_type.should == "image/jpeg"
-    info = image_info(response.body)
-    info[:dimensions].should == [50, 52]
+    image_dimensions(response).should == [50, 52]
   end
 
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -187,4 +187,20 @@ describe Rack::Thumb do
     response.body.should == "File not found: /media/imagick_50x50!.jpg\n"
   end
 
+  it "should render a thumbnail when mounted as a mapped app" do
+    app = Rack::Builder.new do
+            map '/thumb/nail' do
+              use Rack::Thumb
+              run Rack::File.new(::File.dirname(__FILE__))
+            end
+          end
+
+    response = Rack::MockRequest.new(app).get("/thumb/nail/media/imagick_50x.jpg")
+
+    response.should.be.ok
+    response.content_type.should == "image/jpeg"
+    info = image_info(response.body)
+    info[:dimensions].should == [50, 52]
+  end
+
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -141,6 +141,13 @@ describe Rack::Thumb do
     response.body.should == "Bad thumbnail parameters in /media/imagick_0x50.jpg\n"
   end
 
+  it "should return bad request when width has leading zero" do
+    response = mock_request.get("/media/imagick_050x50.jpg")
+
+    response.should.be.client_error
+    response.body.should == "Bad thumbnail parameters in /media/imagick_050x50.jpg\n"
+  end
+
   it "should return bad request with height of 0" do
     response = mock_request.get("/media/imagick_50x0.jpg")
 
@@ -153,13 +160,6 @@ describe Rack::Thumb do
 
     response.should.be.client_error
     response.body.should == "Bad thumbnail parameters in /media/imagick_50x050.jpg\n"
-  end
-
-  it "should return bad request when width has leading zero" do
-    response = mock_request.get("/media/imagick_050x50.jpg")
-
-    response.should.be.client_error
-    response.body.should == "Bad thumbnail parameters in /media/imagick_050x50.jpg\n"
   end
 
   it "should return bad request if the signature is invalid" do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'bacon'
 require File.dirname(File.dirname(__FILE__)) + '/lib/rack/thumb'
 require 'rack/mock'


### PR DESCRIPTION
The biggest feature is to change how rack-thumb responds when passed both a height and width match ImageMagick's operation. "50x50" resizes the image to fit within those bounds without cropping and "50x50!" resizes and crops to exact dimensions. See 7348eef2ffc26416ceb0fcbcdde38b6bf6729c59.

As for the other commits, I made some minor refactorings and pulled in simple commits from [vidibus/rack-thumb](https://github.com/vidibus/rack-thumb) that I needed.
