### PR TITLE
Make file extension optional

### DIFF
--- a/lib/rack/thumb.rb
+++ b/lib/rack/thumb.rb
@@ -52,7 +52,7 @@ module Rack
 
   class Thumb
     RE_TH_BASE = /_([0-9]+x|x[0-9]+|[0-9]+x[0-9]+)(-(?:nw|n|ne|w|c|e|sw|s|se))?/
-    RE_TH_EXT = /(\.(?:jpg|jpeg|png|gif))/i
+    RE_TH_EXT = /(\.(?:jpg|jpeg|png|gif))?/i
     TH_GRAV = {
       '-nw' => :northwest,
       '-n' => :north,
@@ -125,13 +125,13 @@ module Rack
       base, dim, grav, sig, ext = match.captures
       digest = Digest::SHA1.hexdigest("#{base}_#{dim}#{grav}#{ext}#{@secret}")[0..@keylen-1]
       throw(:halt, bad_request) unless sig && (sig == digest)
-      [base + ext, dim, grav]
+      [base + ext.to_s, dim, grav]
     end
 
     # Extracts filename and options from an unsigned path.
     def extract_unsigned_meta(match)
       base, dim, grav, ext = match.captures
-      [base + ext, dim, grav]
+      [base + ext.to_s, dim, grav]
     end
 
     # Fetch the source image from the downstream app, returning the downstream

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -162,4 +162,17 @@ describe Rack::Thumb do
     res = request.post("/media/imagick_50x50.jpg")
     res.should.not.be.successful
   end
+  
+  it "should work for filenames with no extension" do
+    app = lambda { |env| [200, {"Content-Type" => "image/jpeg"},
+        [::File.read(::File.dirname(__FILE__) + "/media/imagick.jpg")]] }
+
+    request = Rack::MockRequest.new(Rack::Thumb.new(app))
+
+    res = request.get("/media/imagick_50x")
+    res.should.be.ok
+    res.content_type.should == "image/jpeg"
+    info = image_info(res.body)
+    info[:dimensions].should == [50, 52]
+  end
 end


### PR DESCRIPTION
Files may not always be identified by their filename.  I am serving images out of a database, for example, where  an image URL might look like:

```
/assets/4ea013cae9fcaa5e4b010001
```

By making the file extension optional, we can generate thumbnails with URLs like:

```
/assets/4ea013cae9fcaa5e4b010001_150x150
```
